### PR TITLE
Add runtime terrain and adjust positions

### DIFF
--- a/MMOClient/Assets/Scenes/test_1.unity
+++ b/MMOClient/Assets/Scenes/test_1.unity
@@ -667,7 +667,7 @@ Transform:
   m_GameObject: {fileID: 1272946133}
   serializedVersion: 2
   m_LocalRotation: {x: -0.014025194, y: -0.014901046, z: -0.0027143462, w: 0.999787}
-  m_LocalPosition: {x: 5, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -959,7 +959,7 @@ Transform:
   m_GameObject: {fileID: 1674668999}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 2, y: 1, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1035,6 +1035,50 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &910000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 910000002}
+  - component: {fileID: 910000003}
+  m_Layer: 0
+  m_Name: EnvironmentBootstrap
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &910000002
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910000001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &910000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 910000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 08a74fbbb8b049b2aee2e4f1cda8b44f, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -1044,3 +1088,4 @@ SceneRoots:
   - {fileID: 1272946136}
   - {fileID: 1674669002}
   - {fileID: 2052191655}
+  - {fileID: 910000002}

--- a/MMOClient/Assets/Scripts/EnsureTerrain.cs
+++ b/MMOClient/Assets/Scripts/EnsureTerrain.cs
@@ -1,0 +1,38 @@
+using UnityEngine;
+
+public class EnsureTerrain : MonoBehaviour
+{
+    void Start()
+    {
+        // Create Terrain if it doesn't exist
+        if (FindObjectOfType<Terrain>() == null)
+        {
+            GameObject terrainGO = new GameObject("Terrain");
+            terrainGO.transform.position = Vector3.zero;
+
+            Terrain terrain = terrainGO.AddComponent<Terrain>();
+            TerrainCollider col = terrainGO.AddComponent<TerrainCollider>();
+
+            TerrainData data = new TerrainData();
+            data.heightmapResolution = 33;
+            data.size = new Vector3(500f, 600f, 500f);
+            data.SetHeights(0, 0, new float[data.heightmapResolution, data.heightmapResolution]);
+
+            terrain.terrainData = data;
+            col.terrainData = data;
+
+            Material mat = new Material(Shader.Find("Standard"));
+            mat.color = Color.green;
+            terrain.materialTemplate = mat;
+        }
+
+        // Fallback plane for simple collision
+        if (GameObject.Find("FallbackPlane") == null)
+        {
+            GameObject plane = GameObject.CreatePrimitive(PrimitiveType.Plane);
+            plane.name = "FallbackPlane";
+            plane.transform.position = Vector3.zero;
+            plane.transform.localScale = Vector3.one;
+        }
+    }
+}

--- a/MMOClient/Assets/Scripts/EnsureTerrain.cs.meta
+++ b/MMOClient/Assets/Scripts/EnsureTerrain.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 08a74fbbb8b049b2aee2e4f1cda8b44f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add an `EnsureTerrain` script that creates a flat Terrain and fallback plane
- reference `EnsureTerrain` in scene via new `EnvironmentBootstrap`
- position Player and NPC slightly above the ground

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872caec54508331837af58ad49bccef