### PR TITLE
Add Phoenix WebSocket chat client

### DIFF
--- a/MMOClient/Assets/Scripts/ChatUIManager.cs
+++ b/MMOClient/Assets/Scripts/ChatUIManager.cs
@@ -1,0 +1,71 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ChatUIManager : MonoBehaviour
+{
+    public PhoenixChatClient chatClient;
+    public Text chatHistoryText;
+    public ScrollRect scrollRect;
+    public InputField inputField;
+    public Button sendButton;
+    public string playerName = "player1";
+
+    void Start()
+    {
+        if (chatClient != null)
+        {
+            chatClient.playerName = playerName;
+            chatClient.OnChatMessage += OnChatMessage;
+        }
+        if (sendButton != null)
+            sendButton.onClick.AddListener(SendFromInput);
+        if (inputField != null)
+            inputField.onEndEdit.AddListener(OnEndEdit);
+    }
+
+    void OnDestroy()
+    {
+        if (chatClient != null)
+            chatClient.OnChatMessage -= OnChatMessage;
+    }
+
+    void OnEndEdit(string text)
+    {
+        if (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter))
+            SendFromInput();
+    }
+
+    void SendFromInput()
+    {
+        if (string.IsNullOrEmpty(inputField.text))
+            return;
+
+        string to = chatClient != null ? chatClient.globalTopic : "chat:global";
+        string message = inputField.text;
+
+        if (message.StartsWith("/w "))
+        {
+            var parts = message.Split(new char[] { ' ' }, 3);
+            if (parts.Length >= 3)
+            {
+                to = "chat:whisper:" + parts[1];
+                message = parts[2];
+            }
+        }
+
+        chatClient?.SendChat(to, message);
+        inputField.text = string.Empty;
+        inputField.ActivateInputField();
+    }
+
+    void OnChatMessage(PhoenixMessage msg)
+    {
+        if (msg.payload == null)
+            return;
+
+        string line = $"[{msg.payload.from}] {msg.payload.text}";
+        chatHistoryText.text += line + "\n";
+        Canvas.ForceUpdateCanvases();
+        scrollRect.verticalNormalizedPosition = 0f;
+    }
+}

--- a/MMOClient/Assets/Scripts/ChatUIManager.cs.meta
+++ b/MMOClient/Assets/Scripts/ChatUIManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 854b37e78a7f4bf4bbbfff6e939bd3b1

--- a/MMOClient/Assets/Scripts/PhoenixChatClient.cs
+++ b/MMOClient/Assets/Scripts/PhoenixChatClient.cs
@@ -1,0 +1,118 @@
+using UnityEngine;
+using WebSocketSharp;
+using System;
+
+[Serializable]
+public class ChatPayload
+{
+    public string from;
+    public string to;
+    public string text;
+}
+
+[Serializable]
+public class PhoenixMessage
+{
+    public string topic;
+    public string @event;
+    public ChatPayload payload;
+    public string @ref;
+    public string join_ref;
+}
+
+[Serializable]
+public class EmptyPayload { }
+
+[Serializable]
+public class JoinMessage
+{
+    public string topic;
+    public string @event;
+    public EmptyPayload payload = new EmptyPayload();
+    public string @ref;
+}
+
+public class PhoenixChatClient : MonoBehaviour
+{
+    public string socketUrl = "ws://localhost:4001/socket/websocket";
+    public string playerName = "player1";
+    public string globalTopic = "chat:global";
+
+    private WebSocket socket;
+    private int refCounter = 1;
+
+    public event Action<PhoenixMessage> OnChatMessage;
+
+    void Start()
+    {
+        Connect();
+    }
+
+    public void Connect()
+    {
+        if (socket != null)
+            return;
+
+        socket = new WebSocket(socketUrl);
+        socket.OnOpen += (s, e) =>
+        {
+            Debug.Log("Connected to Phoenix socket");
+            JoinChannel(globalTopic);
+        };
+        socket.OnMessage += (s, e) => HandleMessage(e);
+        socket.OnError += (s, e) => Debug.LogError("WebSocket error: " + e.Message);
+        socket.ConnectAsync();
+    }
+
+    void HandleMessage(MessageEventArgs e)
+    {
+        if (!e.IsText)
+            return;
+        PhoenixMessage msg = JsonUtility.FromJson<PhoenixMessage>(e.Data);
+        if (msg.@event == "message")
+        {
+            OnChatMessage?.Invoke(msg);
+        }
+        else if (msg.@event == "phx_reply")
+        {
+            Debug.Log("Join reply for " + msg.topic);
+        }
+    }
+
+    void OnDestroy()
+    {
+        if (socket != null)
+        {
+            socket.Close();
+            socket = null;
+        }
+    }
+
+    void JoinChannel(string topic)
+    {
+        var join = new JoinMessage
+        {
+            topic = topic,
+            @event = "phx_join",
+            @ref = (refCounter++).ToString()
+        };
+        string json = JsonUtility.ToJson(join);
+        socket.Send(json);
+    }
+
+    public void SendChat(string toTopic, string text)
+    {
+        if (socket == null || socket.ReadyState != WebSocketState.Open)
+            return;
+
+        PhoenixMessage msg = new PhoenixMessage
+        {
+            topic = toTopic,
+            @event = "message",
+            payload = new ChatPayload { from = playerName, to = toTopic, text = text },
+            @ref = (refCounter++).ToString()
+        };
+        string json = JsonUtility.ToJson(msg);
+        socket.Send(json);
+    }
+}

--- a/MMOClient/Assets/Scripts/PhoenixChatClient.cs.meta
+++ b/MMOClient/Assets/Scripts/PhoenixChatClient.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fcb4264d04ac4286a3f0d276ce8bc4b9

--- a/README.md
+++ b/README.md
@@ -66,3 +66,22 @@ camera and the scroll wheel to zoom.
 
 All network calls are stubbed (`NetworkedEntity` class). Integrate these hooks
 with your Elixir backend to synchronize player and NPC states.
+
+### Chat System
+This repo now includes a lightweight chat client for talking to a Phoenix
+backend over WebSockets. The `PhoenixChatClient` component handles the Phoenix
+socket protocol while `ChatUIManager` drives a simple Unity UI.
+
+1. Download the open source **websocket-sharp** library and place the DLL inside
+   `Assets/Plugins/`.
+2. Add the `PhoenixChatClient` and `ChatUIManager` scripts from `Assets/Scripts`
+   to your scene.
+3. Create a UI panel anchored to the edge of the screen containing a scrollable
+   `Text` element for history, an `InputField` and a **Send** button.
+4. Assign the UI elements and the `PhoenixChatClient` reference on the
+   `ChatUIManager` component.
+5. Press Play and type messages. Use `/w <target> <message>` in the input field
+   to send a whisper (topic `chat:whisper:<target>`).
+
+Messages are sent in Phoenix JSON format and the client automatically joins the
+`"chat:global"` channel on connect.


### PR DESCRIPTION
## Summary
- implement `PhoenixChatClient` for communicating with Phoenix backend via WebSockets
- add `ChatUIManager` to drive Unity UI
- document setup instructions in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68731e75ea50833181a19d2fae89df90