### PR TITLE
Implement MMO-style chat toggle

### DIFF
--- a/MMOClient/Assets/Scripts/ChatUIManager.cs
+++ b/MMOClient/Assets/Scripts/ChatUIManager.cs
@@ -10,10 +10,11 @@ public class ChatUIManager : MonoBehaviour
     public TMP_InputField inputField;
     public Button sendButton;
     public string playerName = "player1";
+    public bool chatActive = false;
 
     void Start()
     {
-
+        Cursor.lockState = CursorLockMode.Locked;
         Debug.Log("✅ ChatUIManager STARTED");
         if (chatClient != null)
         {
@@ -33,11 +34,31 @@ public class ChatUIManager : MonoBehaviour
 
     void Update()
     {
-        if (inputField != null && inputField.isFocused &&
-            (Input.GetKeyDown(KeyCode.Return) || Input.GetKeyDown(KeyCode.KeypadEnter)))
+        if (!chatActive)
         {
-            Debug.Log("⏎ Enter detected while input is focused");
-            SendFromInput();
+            if (Input.GetKeyDown(KeyCode.Return))
+            {
+                chatActive = true;
+                Cursor.lockState = CursorLockMode.None;
+                inputField.ActivateInputField();
+            }
+        }
+        else
+        {
+            if (Input.GetKeyDown(KeyCode.Escape))
+            {
+                chatActive = false;
+                inputField.text = string.Empty;
+                inputField.DeactivateInputField();
+                Cursor.lockState = CursorLockMode.Locked;
+            }
+            else if (Input.GetKeyDown(KeyCode.Return))
+            {
+                SendFromInput();
+                chatActive = false;
+                inputField.DeactivateInputField();
+                Cursor.lockState = CursorLockMode.Locked;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- add `chatActive` field to handle chat mode
- lock cursor on start by default
- toggle chat mode in `Update()` with Enter/Escape

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687454b01a2c8331b7e6c9da62cec6a8