### PR TITLE
Remove invalid OnLand AnimationEvent

### DIFF
--- a/MMOClient/Assets/Editor/RemoveInvalidAnimationEvents.cs
+++ b/MMOClient/Assets/Editor/RemoveInvalidAnimationEvents.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+public static class RemoveInvalidAnimationEvents
+{
+    [MenuItem("Tools/Remove Invalid JumpLand Events")]
+    private static void CleanJumpLandEvents()
+    {
+        string assetPath = "Assets/StarterAssets/ThirdPersonController/Character/Animations/Jump--Jump.anim.fbx";
+        AnimationClip clip = FindClip(assetPath, "JumpLand");
+        if (clip == null)
+        {
+            Debug.LogWarning("JumpLand clip not found");
+            return;
+        }
+
+        List<AnimationEvent> validEvents = new List<AnimationEvent>();
+        bool changed = false;
+        foreach (var evt in AnimationUtility.GetAnimationEvents(clip))
+        {
+            if (string.IsNullOrEmpty(evt.functionName))
+                continue;
+
+            if (!MethodExists(evt.functionName) || evt.functionName == "OnLand")
+            {
+                changed = true;
+                continue;
+            }
+            validEvents.Add(evt);
+        }
+
+        if (changed)
+        {
+            AnimationUtility.SetAnimationEvents(clip, validEvents.ToArray());
+            EditorUtility.SetDirty(clip);
+            AssetDatabase.SaveAssets();
+            Debug.Log("Removed invalid events from JumpLand");
+        }
+        else
+        {
+            Debug.Log("No invalid events found on JumpLand");
+        }
+    }
+
+    private static AnimationClip FindClip(string assetPath, string clipName)
+    {
+        foreach (var a in AssetDatabase.LoadAllAssetsAtPath(assetPath))
+        {
+            if (a is AnimationClip clip && clip.name == clipName)
+                return clip;
+        }
+        return null;
+    }
+
+    private static bool MethodExists(string name)
+    {
+        foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            foreach (var type in asm.GetTypes())
+            {
+                if (typeof(MonoBehaviour).IsAssignableFrom(type) &&
+                    type.GetMethod(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic) != null)
+                    return true;
+            }
+        }
+        return false;
+    }
+}

--- a/MMOClient/Assets/Editor/RemoveInvalidAnimationEvents.cs.meta
+++ b/MMOClient/Assets/Editor/RemoveInvalidAnimationEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ddddddddddddddd11111111111111111
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MMOClient/Assets/StarterAssets/ThirdPersonController/Character/Animations/Jump--Jump.anim.fbx.meta
+++ b/MMOClient/Assets/StarterAssets/ThirdPersonController/Character/Animations/Jump--Jump.anim.fbx.meta
@@ -93,14 +93,7 @@ ModelImporter:
       mirror: 0
       bodyMask: 01000000010000000100000001000000010000000100000001000000010000000100000001000000010000000100000001000000
       curves: []
-      events:
-      - time: 0.1615599
-        functionName: OnLand
-        data: 
-        objectReferenceParameter: {instanceID: 0}
-        floatParameter: 0
-        intParameter: 0
-        messageOptions: 0
+      events: []
       transformMask: []
       maskType: 3
       maskSource: {instanceID: 0}


### PR DESCRIPTION
## Summary
- strip the `OnLand` event from the JumpLand clip
- add an editor utility to scrub invalid events from the JumpLand animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687566eeb6ac8331adc8b5f21f13284a